### PR TITLE
Fixed a Bug in molecule.py -> reoriented_molecule

### DIFF
--- a/pyxtal/molecule.py
+++ b/pyxtal/molecule.py
@@ -1413,7 +1413,7 @@ def reoriented_molecule(mol): #, nested=False):
     A = get_inertia_tensor(coords)
     # Store the eigenvectors of the inertia tensor
     P = np.linalg.eigh(A)[1]
-    if np.linalg.det(P) < 0: P[0] *= -1
+    if np.linalg.det(P) < 0: P[:,0] *= -1
     coords = np.dot(coords, P)
     return Molecule(numbers, coords), P
 


### PR DESCRIPTION
The first collumn and not row should be multiplied with -1, otherwise it fails the rotation along cartesian coordinates. Affects estimation of box volume (overestimation if the molecule is wrong aligned) and therefore the density of initial random molecular crystals (underestimated).