### PR TITLE
Update __init__.py

### DIFF
--- a/pyxtal/__init__.py
+++ b/pyxtal/__init__.py
@@ -583,7 +583,7 @@ class pyxtal:
 
         from pyxtal.supergroup import supergroup
 
-        my_super = supergroup(self, G=G, group_type=group_type)
+        my_super = supergroup(self, G=G)
         solutions = my_super.search_supergroup(d_tol=d_tol)
         return my_super.make_supergroup(solutions)
 


### PR DESCRIPTION
Hello, great library! The function supergroup was not working for me.  I was gettting the following error:

newStruc = struc.supergroup(G=int(superGroup[2]))
  File "/home/chemist/.local/lib/python3.7/site-packages/pyxtal/__init__.py", line 581, in supergroup
    my_super = supergroup(self, G=G, group_type=group_type)
TypeError: __init__() got an unexpected keyword argument 'group_type'

I fixed this changing the line:
 my_super = supergroup(self, G=G, group_type=group_type)

To:
my_super = supergroup(self, G=G)