### PR TITLE
Fix typo in Tol_matrix.get_tol

### DIFF
--- a/pyxtal/tolerance.py
+++ b/pyxtal/tolerance.py
@@ -99,7 +99,7 @@ class Tol_matrix:
         Returns:
             the tolerance between the provided pair of atomic species
         """
-        if self.prototype == "single_value":
+        if self.prototype == "single value":
             return self.matrix[0][0]
         index1 = Element.number_from_specie(specie1)
         index2 = Element.number_from_specie(specie2)


### PR DESCRIPTION
This prevented the constructor `from_single_value` to work correctly.  That method sets the `prototype` to `single value` (no underscore), but `get_tol` checks for `single_value` (with underscore).

I've just changed this quickly in the github editor and didn't do any further tests.