### PR TITLE
Migrate pkg_resources to importlib.resources

### DIFF
--- a/pyxtal/XRD.py
+++ b/pyxtal/XRD.py
@@ -3,16 +3,19 @@ Module for XRD simulation (experimental stage)
 """
 
 import collections
+import importlib.resources
 import os
 
 import numpy as np
 from monty.serialization import loadfn
-from pkg_resources import resource_filename
 from scipy.interpolate import interp1d
 
 from pyxtal.database.element import Element
 
-ATOMIC_SCATTERING_PARAMS = loadfn(resource_filename("pyxtal", "database/atomic_scattering_params.json"))
+with importlib.resources.as_file(
+    importlib.resources.files("pyxtal") / "database" / "atomic_scattering_params.json"
+) as path:
+    ATOMIC_SCATTERING_PARAMS = loadfn(path)
 
 
 class XRD:

--- a/pyxtal/descriptor.py
+++ b/pyxtal/descriptor.py
@@ -584,14 +584,15 @@ class orientation_order:
 
 
 if __name__ == "__main__":
-    from pkg_resources import resource_filename
+    import importlib.resources
 
     from pyxtal import pyxtal
 
-    cif_path = resource_filename("pyxtal", "database/cifs/")
+    with importlib.resources.as_file(importlib.resources.files("pyxtal") / "database" / "cifs") as path:
+        cif_path = path
     c1 = pyxtal(molecular=True)
     for name in ["benzene", "resorcinol", "aspirin", "naphthalene"]:
-        c1.from_seed(seed=cif_path + name + ".cif", molecules=[name])
+        c1.from_seed(seed=str(cif_path / f"{name}.cif"), molecules=[name])
         for model in ["contact", "molecule"]:
             print(name, model)
             sph = spherical_image(c1, model=model, lmax=18)

--- a/pyxtal/interface/lammpslib.py
+++ b/pyxtal/interface/lammpslib.py
@@ -1,5 +1,6 @@
 """ASE LAMMPS Calculator Library Version"""
 
+import importlib.resources
 import os
 
 import ase.units
@@ -10,7 +11,6 @@ from ase.optimize import LBFGS
 from ase.optimize.fire import FIRE
 from ase.spacegroup.symmetrize import FixSymmetry
 from lammps import lammps
-from pkg_resources import resource_filename
 
 
 #
@@ -207,7 +207,8 @@ class LAMMPSlib(Calculator):
             os.makedirs(self.folder)
         self.lammps_data = self.folder + "/data.lammps"
         self.lammps_in = self.folder + "/in.lammps"
-        self.ffpath = resource_filename("pyxtal", "potentials")
+        with importlib.resources.as_file(importlib.resources.files("pyxtal") / "potentials") as path:
+            self.ffpath = str(path)
         self.lmpcmds = lmpcmds
         self.paras = []
         if lmpcmds is not None:

--- a/pyxtal/io.py
+++ b/pyxtal/io.py
@@ -2,9 +2,10 @@
 This module handles reading and write crystal files.
 """
 
+import importlib.resources
+
 import numpy as np
 from monty.serialization import loadfn
-from pkg_resources import resource_filename
 from pymatgen.core.bonds import CovalentBond
 from pymatgen.core.structure import Molecule, Structure
 
@@ -16,7 +17,8 @@ from pyxtal.symmetry import Group
 from pyxtal.util import get_symmetrized_pmg
 from pyxtal.wyckoff_site import atom_site, mol_site
 
-bonds = loadfn(resource_filename("pyxtal", "database/bonds.json"))
+with importlib.resources.as_file(importlib.resources.files("pyxtal") / "database" / "bonds.json") as path:
+    bonds = loadfn(path)
 
 
 def in_merged_coords(wp, pt, pts, cell):

--- a/pyxtal/miscellaneous/test_read.py
+++ b/pyxtal/miscellaneous/test_read.py
@@ -1,6 +1,7 @@
+import importlib.resources
+
 import numpy as np
 import pymatgen.analysis.structure_matcher as sm
-from pkg_resources import resource_filename
 from pymatgen.core.structure import Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from rdkit import Chem
@@ -24,7 +25,8 @@ lists = [
 for mol in lists:
     (smi, cif) = mol
     m = Chem.MolFromSmiles(smi)
-    cif = resource_filename("pyxtal", "database/cifs/") + cif
+    with importlib.resources.as_file(importlib.resources.files("pyxtal") / "database" / "cifs") as path:
+        cif = str(path / cif)
     m2 = Chem.AddHs(m)
     m3 = Chem.AddHs(m2)
     AllChem.EmbedMultipleConfs(m3)

--- a/pyxtal/miscellaneous/test_supergroup.py
+++ b/pyxtal/miscellaneous/test_supergroup.py
@@ -1,6 +1,5 @@
+import importlib.resources
 from time import time
-
-from pkg_resources import resource_filename
 
 from pyxtal import pyxtal
 from pyxtal.supergroup import supergroups
@@ -17,18 +16,19 @@ data = {
     # "MPWO": 225,
 }
 
-cif_path = resource_filename("pyxtal", "database/cifs/")
+with importlib.resources.as_file(importlib.resources.files("pyxtal") / "database" / "cifs") as path:
+    cif_path = path
 
 for cif in data:
     t0 = time()
     print("===============", cif, "===============")
     for tol in [1e-5, 1e-4, 1e-3, 1e-2, 1e-1, 1]:
         s = pyxtal()
-        s.from_seed(cif_path + cif + ".cif", tol=tol)
+        s.from_seed(str(cif_path / f"{cif}.cif"), tol=tol)
         print("tol", tol, s.group.number)
 
     s = pyxtal()
-    s.from_seed(cif_path + cif + ".cif")
+    s.from_seed(str(cif_path / f"{cif}.cif"))
     if isinstance(data[cif], list):
         sup = supergroups(s, path=data[cif], show=True, max_per_G=2500)
     else:

--- a/pyxtal/molecule.py
+++ b/pyxtal/molecule.py
@@ -2,6 +2,7 @@
 Module for handling molecules.
 """
 
+import importlib.resources
 import os
 import re
 from copy import deepcopy
@@ -11,7 +12,6 @@ from random import choice
 import networkx as nx
 import numpy as np
 from monty.serialization import loadfn
-from pkg_resources import resource_filename
 
 # External Libraries
 from pymatgen.core.structure import Molecule
@@ -29,7 +29,9 @@ from pyxtal.symmetry import Group
 from pyxtal.tolerance import Tol_matrix
 
 # Define functions
-bonds = loadfn(resource_filename("pyxtal", "database/bonds.json"))
+with importlib.resources.as_file(importlib.resources.files("pyxtal") / "database" / "bonds.json") as path:
+    bonds = loadfn(path)
+
 molecule_collection = Collection("molecules")
 
 


### PR DESCRIPTION
Because [`pkg_resources` is deprecated in favor of `importlib.resources`](https://setuptools.pypa.io/en/latest/pkg_resources.html), this PR migrates the use of `pkg_resources.resource_filename()` to an officially recommended way. 
https://importlib-resources.readthedocs.io/en/latest/migration.html#pkg-resources-resource-filename

These functions are available in Python>=3.9, so I think updating dependency is unnecessary.