### PR TITLE
Fix KeyError when `_` environment variable is not set

### DIFF
--- a/pyxtal/XRD.py
+++ b/pyxtal/XRD.py
@@ -536,7 +536,7 @@ class XRD:
             title="PXRD of " + self.name,
         )
 
-        if os.environ["_"].find("jupyter") == -1:
+        if os.environ.get("_", "").find("jupyter") == -1:
             if html is None:
                 return fig.to_html()
             else:


### PR DESCRIPTION
The `_` environment variable is not guaranteed to exist in all environments. This PR replaces `os.environ["_"]` with `os.environ.get("_", "")` to prevent KeyError.

```diff
-         if os.environ["_"].find("jupyter") == -1:
+         if os.environ.get("_", "").find("jupyter") == -1:
```

https://github.com/MaterSim/PyXtal/blob/f5560b4941c1d4bc9ff01be5fa93ea6263a3d824/pyxtal/XRD.py#L539